### PR TITLE
Adding that the threads stop when they pass the threshold

### DIFF
--- a/src/main/java/co/eci/blacklist/domain/BlacklistChecker.java
+++ b/src/main/java/co/eci/blacklist/domain/BlacklistChecker.java
@@ -1,14 +1,14 @@
 package co.eci.blacklist.domain;
 
-import co.eci.blacklist.infrastructure.HostBlackListsDataSourceFacade;
-import co.eci.blacklist.labs.part2.ParallelBlacklistSearchThread;
-
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
+
+import co.eci.blacklist.infrastructure.HostBlackListsDataSourceFacade;
+import co.eci.blacklist.labs.part2.ParallelBlacklistSearchThread;
 
 public class BlacklistChecker {
 
@@ -27,18 +27,18 @@ public class BlacklistChecker {
         int total = facade.getRegisteredServersCount();
 
         long start = System.currentTimeMillis();
-        int checked = 0;
         AtomicBoolean stop = new AtomicBoolean(false);
-        List<Integer> matches = Collections.synchronizedList(new ArrayList<>());
+        AtomicInteger globalCounter = new AtomicInteger(0);
+        List<Integer> matches = new ArrayList<>();
 
         int threadsCount = Math.max(1, nThreads);
         int chunk = Math.max(1, total / threadsCount);
 
-        ParallelBlacklistSearchThread[] threads = new ParallelBlacklistSearchThread[nThreads];
+        ParallelBlacklistSearchThread[] threads = new ParallelBlacklistSearchThread[threadsCount];
         for (int i = 0; i < threadsCount; i++) {
                 final int startIdx = i * chunk;
                 final int endIdx = (i == threadsCount - 1) ? total : Math.min(total, (i + 1) * chunk);
-                threads[i] = new ParallelBlacklistSearchThread(ip, startIdx, endIdx, facade, stop, threshold);
+                threads[i] = new ParallelBlacklistSearchThread(ip, startIdx, endIdx, facade, globalCounter, stop, threshold);
         }
         
         for (ParallelBlacklistSearchThread t : threads) {
@@ -54,18 +54,18 @@ public class BlacklistChecker {
         }
         for (ParallelBlacklistSearchThread t : threads) {
             matches.addAll(t.getBlackListOccurrences());
-            checked += t.getTotalChecked();
+
         }
 
-        int found = matches.size();
-        boolean trustworthy = found < threshold;
-        logger.info("Checked blacklists: " + checked + " of " + total);
+        int totalCoincidences = globalCounter.get();
+        boolean trustworthy = totalCoincidences < threshold;
+        logger.info("Checked blacklists: " + totalCoincidences + " of " + total);
         if (trustworthy) {
             facade.reportAsTrustworthy(ip);
         } else {
             facade.reportAsNotTrustworthy(ip);
         }
         long elapsed = System.currentTimeMillis() - start;
-        return new MatchResult(ip, trustworthy, List.copyOf(matches), checked, total, elapsed, threadsCount);
+        return new MatchResult(ip, trustworthy, List.copyOf(matches), totalCoincidences, total, elapsed, threadsCount);
     }
 }

--- a/src/main/java/co/eci/blacklist/labs/part2/ParallelBlacklistSearchThread.java
+++ b/src/main/java/co/eci/blacklist/labs/part2/ParallelBlacklistSearchThread.java
@@ -9,6 +9,7 @@ package co.eci.blacklist.labs.part2;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import co.eci.blacklist.infrastructure.HostBlackListsDataSourceFacade;
 
@@ -21,9 +22,11 @@ public class ParallelBlacklistSearchThread extends Thread {
     private final int endServer;
     private final HostBlackListsDataSourceFacade facade;
     private final List<Integer> blackListOccurrences;
+    private AtomicInteger globalCounter;
     private final AtomicBoolean stop;
     private int totalChecked = 0;
     private int threshold;
+    
 
     /**
      * Constructor del hilo de busqueda paralela.
@@ -34,12 +37,13 @@ public class ParallelBlacklistSearchThread extends Thread {
      * @param stop Bandera atomica para detener la busqueda global
      * @param threshold Umbral de coincidencias para detener la busqueda
      */
-    public ParallelBlacklistSearchThread(String ip, int startServer, int endServer, HostBlackListsDataSourceFacade facade, AtomicBoolean stop, int threshold) {
+    public ParallelBlacklistSearchThread(String ip, int startServer, int endServer, HostBlackListsDataSourceFacade facade, AtomicInteger globalCounter, AtomicBoolean stop, int threshold) {
         this.ip = ip;
         this.startServer = startServer;
         this.endServer = endServer;
         this.facade = facade;
         this.blackListOccurrences = new ArrayList<>();
+        this.globalCounter = globalCounter;
         this.stop = stop; 
         this.threshold=threshold;  
     }
@@ -77,7 +81,8 @@ public class ParallelBlacklistSearchThread extends Thread {
             if (stop.get()) break;
             if (facade.isInBlackListServer(i, ip)) {
                 blackListOccurrences.add(i);
-                if (blackListOccurrences.size() >= threshold) {
+                int total = globalCounter.incrementAndGet();
+                if (total >= threshold) {
                     stop.set(true);
                 }
             }

--- a/src/test/java/co/eci/blacklist/domain/BlacklistCheckerTest.java
+++ b/src/test/java/co/eci/blacklist/domain/BlacklistCheckerTest.java
@@ -1,9 +1,12 @@
 package co.eci.blacklist.domain;
 
-import co.eci.blacklist.infrastructure.HostBlackListsDataSourceFacade;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import co.eci.blacklist.infrastructure.HostBlackListsDataSourceFacade;
 
 public class BlacklistCheckerTest {
 


### PR DESCRIPTION
We use the atomicInteger variable globalCount to count the total of servers that are in the blackList. If 1 thread find 1 blackIp and other thread in the same time find 4 blackip's, the other threads stop their searching